### PR TITLE
Polyfill window to self for use inside service workers

### DIFF
--- a/UTIF.js
+++ b/UTIF.js
@@ -1,6 +1,9 @@
 
 ;(function(){
 var UTIF = {};
+	
+// Allows us to use this inside ServiceWorker
+if (typeof window === 'undefined' && typeof self !== 'undefined') window = self;
 
 // Make available for import by `require()`
 if (typeof module == "object") {module.exports = UTIF;}


### PR DESCRIPTION
By aliasing window to self, we can use UTIF.js inside service workers, freeing up the UI thread and processing TIFF images in the background.

It's a small, bc change.