### PR TITLE
Make replaceIMG more robust for img tags without src attribute

### DIFF
--- a/UTIF.js
+++ b/UTIF.js
@@ -590,7 +590,7 @@ UTIF.replaceIMG = function()
 {
 	var imgs = document.getElementsByTagName("img");
 	for (var i=0; i<imgs.length; i++) {
-		var img=imgs[i], src=img.getAttribute("src"), suff=src.split(".").pop().toLowerCase();
+		var img=imgs[i], src=img.getAttribute("src") || "", suff=src.split(".").pop().toLowerCase();
 		if(suff!="tif" && suff!="tiff") continue;
 		var xhr = new XMLHttpRequest();  UTIF._xhrs.push(xhr);  UTIF._imgs.push(img);
 		xhr.open("GET", src);  xhr.responseType = "arraybuffer";


### PR DESCRIPTION
Since `replaceIMG` automatically grabs all img tags it fails for tags without a src attribute.

src is a required attribute but it is not always filled in our case. we are displaying patent data html and some img tags do not include a src:

````
<figure id="f0001" num="">
    <img id="if0001" file="imgf0001.tif" wi="164" he="233" img-content="drawing" img-format="tif">
</figure>
````

For this use-case this patch is enough but maybe I'll add another PR with more functionality (if thats ok)