### PR TITLE
Added Node environment support for DNG files 

### DIFF
--- a/UTIF.js
+++ b/UTIF.js
@@ -16,8 +16,7 @@ else {pako = self.pako;}
 
 var LosslessJpegDecoder;
 try {
-	// If node environment, require lossless-jpeg-decoder otherwise take global from window object
-	if (typeof require === 'function') { LosslessJpegDecoder = require('lossless-jpeg-decoder') }
+	if (typeof require == 'function') { LosslessJpegDecoder = require('lossless-jpeg-decoder') }
 	else { LosslessJpegDecoder = window && window.LosslessJpegDecoder }
 } catch (e) { /* optional, so trap and ignore error*/}
 

--- a/UTIF.js
+++ b/UTIF.js
@@ -17,7 +17,7 @@ else {pako = self.pako;}
 var LosslessJpegDecoder;
 try {
 	// If node environment, require lossless-jpeg-decoder otherwise take global from window object
-	if (process && process.title === 'node') { LosslessJpegDecoder = require('lossless-jpeg-decoder') }
+	if (typeof require === 'function') { LosslessJpegDecoder = require('lossless-jpeg-decoder') }
 	else { LosslessJpegDecoder = window && window.LosslessJpegDecoder }
 } catch (e) { /* optional, so trap and ignore error*/}
 

--- a/UTIF.js
+++ b/UTIF.js
@@ -5,6 +5,7 @@
 ;(function(){
 var UTIF = {};
 
+
 // Make available for import by `require()`
 if (typeof module == "object") {module.exports = UTIF;}
 else {self.UTIF = UTIF;}
@@ -12,6 +13,13 @@ else {self.UTIF = UTIF;}
 var pako;
 if (typeof require == "function") {pako = require("pako");}
 else {pako = self.pako;}
+
+var LosslessJpegDecoder;
+try {
+	// If node environment, require lossless-jpeg-decoder otherwise take global from window object
+	if (process && process.title === 'node') { LosslessJpegDecoder = require('lossless-jpeg-decoder') }
+	else { LosslessJpegDecoder = window && window.LosslessJpegDecoder }
+} catch (e) { /* optional, so trap and ignore error*/}
 
 function log() { if (typeof process=="undefined" || process.env.NODE_ENV=="development") console.log.apply(console, arguments);  }
 
@@ -304,14 +312,11 @@ UTIF.decode._decodeNewJPEG = function(img, data, off, len, tgt, toff)
 	{
 		var bps = img["t258"][0];
 		var dcdr; 
+		
+		// Try/catch is not essential, only adds improved error message if LosslessJpegDecoder is not be defined
 		try { 
-			// If node environment, require lossless-jpeg-decoder otherwise take global from window object
-			const LosslessJpegDecoder = (process && process.title === 'node')
-				? require('lossless-jpeg-decoder')
-				: window && window.LosslessJpegDecoder
 			dcdr = new LosslessJpegDecoder();
 		} catch (err) {
-			// catch error from invalid require statement or undefined decoder and output useful error stmt
 			throw new Error("In order to process DNG images you must include lossless-jpeg-decoder. Package should be installed (node) or included in script tag (browser)");
 		}
 			

--- a/UTIF.js
+++ b/UTIF.js
@@ -302,7 +302,19 @@ UTIF.decode._decodeNewJPEG = function(img, data, off, len, tgt, toff)
 
 	if(img["t262"]==32803) // lossless JPEG (used in DNG files) is not available in JpegDecoder.
 	{
-		var bps = img["t258"][0], dcdr = new LosslessJpegDecoder();
+		var bps = img["t258"][0];
+		var dcdr; 
+		try { 
+			// If node environment, require lossless-jpeg-decoder otherwise take global from window object
+			const LosslessJpegDecoder = (process && process.title === 'node')
+				? require('lossless-jpeg-decoder')
+				: window && window.LosslessJpegDecoder
+			dcdr = new LosslessJpegDecoder();
+		} catch (err) {
+			// catch error from invalid require statement or undefined decoder and output useful error stmt
+			throw new Error("In order to process DNG images you must include lossless-jpeg-decoder. Package should be installed (node) or included in script tag (browser)");
+		}
+			
 		var out = dcdr.decode(buff), olen=out.length;
 
 		if(false) {}


### PR DESCRIPTION
This PR adds support for DNG files in a node execution environment by adding a require statement if executing in a node environment and attempting to decode a DNG image.  If lossless-jpeg-decoder is not present (either as an installed module in node or via script tag in browser), it will throw an error specifying that lossless-jpeg-decoder must be installed/included via script tag in order to process DMG images (in place of 'LosslessJpegDecoder is undefined' error. 

It may be better to move the LosslessJpegDecoder assignment to the top of file similar to pako.  Any error can be trapped and ignored (since most users are not using DNG).  Let me know if you would prefer it that way or if you've got any questions/comments/requests/critiques. 