### PR TITLE
Use zlib instead of pako to read zip compression 4.5× faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ You should not save images into TIFF format in the 21st century. Save them as PN
 * returns ArrayBuffer of binary data. You can use it to encode EXIF data.
 
 ## Dependencies
-TIFF format sometimes uses Inflate algorithm for compression (but it is quite rare). Right now, UTIF.js calls [Pako.js](https://github.com/nodeca/pako) for the Inflate method.
+TIFF format sometimes uses Inflate algorithm for compression (but it is quite rare). Right now, UTIF.js calls for Inflate method in [zlib](https://nodejs.org/api/zlib.html#zlibinflatesyncbuffer-options) when running NodeJS 8.0.0 or higher otherwise  [Pako.js](https://github.com/nodeca/pako).

--- a/UTIF.js
+++ b/UTIF.js
@@ -9,11 +9,23 @@ var UTIF = {};
 if (typeof module == "object") {module.exports = UTIF;}
 else {self.UTIF = UTIF;}
 
-var pako = (typeof require === "function") ? require("pako") : self.pako;
+// Make sure to have something for decompression of Tiff files that are using Zip compression
+var inflate = null;
+// If is NodeJS
+if (typeof require === "function" && typeof process ==="object"  && typeof process.versions ==="object" &&  typeof process.versions.node ==="string")
+{
+	// Is NodeJS version 8.0 and higher where inflate can accept Uint8Array
+	if (parseInt(process.versions.node.split(".")[0]) >= 8) { inflate = require("zlib").inflateSync}
+	// Otherwise use "pako"
+	else { inflate = require("pako").inflate}
+}
+// Not a Node.js
+else if(typeof self ==="undefined" || "pako" in self === false){throw new Error("Pako not found. This is needed to open Tiff files that are using Zip compression")}
+else {inflate = self.pako.inflate}
 
 function log() { if (typeof process=="undefined" || process.env.NODE_ENV=="development") console.log.apply(console, arguments);  }
 
-(function(UTIF, pako){
+(function(UTIF, inflate){
 	
 // Following lines add a JPEG decoder  to UTIF.JpegDecoder
 (function(){"use strict";var W=function a1(){function W(p){this.message="JPEG error: "+p}W.prototype=new Error;W.prototype.name="JpegError";W.constructor=W;return W}(),ak=function ag(){var p=new Uint8Array([0,1,8,16,9,2,3,10,17,24,32,25,18,11,4,5,12,19,26,33,40,48,41,34,27,20,13,6,7,14,21,28,35,42,49,56,57,50,43,36,29,22,15,23,30,37,44,51,58,59,52,45,38,31,39,46,53,60,61,54,47,55,62,63]),t=4017,ac=799,ah=3406,ao=2276,ar=1567,ai=3784,s=5793,ad=2896;function ak(Q){if(Q==null)Q={};if(Q.w==null)Q.w=-1;this.V=Q.n;this.N=Q.w}function a5(Q,h){var f=0,G=[],n,E,a=16,F;while(a>0&&!Q[a-1]){a--}G.push({children:[],index:0});var C=G[0];for(n=0;n<a;n++)
@@ -170,7 +182,7 @@ UTIF.decode._decompress = function(img,ifds, data, off, len, cmpr, tgt, toff, fo
 	else if(cmpr==5) UTIF.decode._decodeLZW(data, off, len, tgt, toff,8);
 	else if(cmpr==6) UTIF.decode._decodeOldJPEG(img, data, off, len, tgt, toff);
 	else if(cmpr==7 || cmpr==34892) UTIF.decode._decodeNewJPEG(img, data, off, len, tgt, toff);
-	else if(cmpr==8 || cmpr==32946) {  var src = new Uint8Array(data.buffer,off,len);  var bin = pako["inflate"](src);  for(var i=0; i<bin.length; i++) tgt[toff+i]=bin[i];  }
+	else if (cmpr==8 || cmpr==32946) {var src = new Uint8Array(data.buffer, off, len); var bin = inflate(src);  for(var i=0; i<bin.length; i++) tgt[toff+i]=bin[i];  }
 	else if(cmpr==9) UTIF.decode._decodeVC5(data,off,len,tgt,toff);
 	else if(cmpr==32767) UTIF.decode._decodeARW(img, data, off, len, tgt, toff);
 	else if(cmpr==32773) UTIF.decode._decodePackBits(data, off, len, tgt, toff);
@@ -1355,5 +1367,5 @@ a<u.A;a++){o[X][a]=0}}}B(o)}}return V}}())
 
 
 
-})(UTIF, pako);
+})(UTIF, inflate);
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,28 @@
 {
   "name": "utif",
-  "version": "1.3.0",
-  "lockfileVersion": 1,
+  "version": "3.1.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "utif",
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.11"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    }
+  },
   "dependencies": {
     "pako": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "conversion"
   ],
   "dependencies": {
-    "pako": "^1.0.5"
+    "pako": "^1.0.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "utif",
   "description": "Fast and advanced TIFF decoder",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "homepage": "https://github.com/photopea/UTIF.js",
   "author": "photopea (https://github.com/photopea)",
   "contributors": [


### PR DESCRIPTION
I tested Tiff file with ZIP compression:
3000 × 4000px, 14.6MB input, 45.7MB output

Inflate with "pako" took 230-240ms.
Inflate with "zlib" took 47-50ms.
So it is about 4.5× faster while producing same results.

Code to test performance:
```
const read = require("fs/promises").readFile;
const write = require("fs/promises").writeFile;
const UTIF = require("./UTIF");

(async () => {
	const buf = await read("c:/yourPath/in.tif");
	
	var ifds = UTIF.decode(buf);
	UTIF.decodeImage(buf, ifds[0])
	var rgba = UTIF.toRGBA8(ifds[0]);  // Uint8Array with RGBA pixels
	const outBuf = UTIF.encodeImage(rgba, ifds[0].width, ifds[0].height);
	
	await write("c:/yourPath/out.tif", Buffer.from(outBuf));	
})()

```
Also I do recomend to wrap `inflate()` command into `console.time()` and `console.timeEnd()` to measure performance only for inflate. (line 185)