### PR TITLE
Check for window existence before accessing UDOC

### DIFF
--- a/UTIF.js
+++ b/UTIF.js
@@ -1458,7 +1458,7 @@ UTIF.toRGBA8 = function(out, scl)
 		for(var i=0; i<area; i++) {
 			var qi=i<<2, si=i*smpls;  
 			
-			if(window.UDOC) {
+			if(window && window.UDOC) {
 				var C=data[si], M=data[si+1], Y=data[si+2], K=data[si+3];
 				var c = UDOC.C.cmykToRgb([C*(1/255), M*(1/255), Y*(1/255), K*(1/255)]);
 				img[qi] = ~~(0.5+255*c[0]);  img[qi+1] = ~~(0.5+255*c[1]);  img[qi+2] = ~~(0.5+255*c[2]);


### PR DESCRIPTION
@photopea Thank you for maintaining this project.

As already pointed out by jardicc https://github.com/photopea/UTIF.js/issues/106#issuecomment-2022356952 and markb-trustifi #130 , checking for the existence of the global `window` object improves portability to non-browser environments.

A similar change has already been made at [line 43](https://github.com/photopea/UTIF.js/blob/2e6be655cb1beee3b4fc193deefee35b10b3a68c/UTIF.js#L43), so I would like to suggest applying the same change here as well for consistency and broader compatibility.